### PR TITLE
remove unused import statement from index.astro

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,8 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 import ProjectCard from '../components/ProjectCard.astro';
 import TechBadge from '../components/TechBadge.astro';
-// import Card from '../components/Card.astro';
-//
+
 const githubUrl = "https://github.com"
 const myGithubUrl = githubUrl + "/bernoussama";
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove the commented-out import of the Card component from src/pages/index.astro